### PR TITLE
fix typo in ICP causing error

### DIFF
--- a/mesh/icp.m
+++ b/mesh/icp.m
@@ -92,7 +92,7 @@ function [R,t,BRt,e,KDTA,KDTB] = icp(A,B,varargin)
     if ~isinf(max_samples)
       IA = randperm(size(A,1));
       IA = IA(1:max_samples);
-      IB = randperm(size(A,1));
+      IB = randperm(size(B,1));
       IB = IB(1:max_samples);
     end
 


### PR DESCRIPTION
Fixes the typo which caused error in `icp(A,B,varargin)` if `#A` is bigger than `#B`.

For instance, calling `icp(rand(100,2),rand(10,2))` throws `Index exceeds matrix dimensions` on line 99.