### PR TITLE
Add set_R method to complement set_new_C

### DIFF
--- a/mesh/deform.m
+++ b/mesh/deform.m
@@ -435,6 +435,11 @@ classdef deform < handle
       this.new_C = new_C;
       this.update_positions();
     end
+    
+    function this = set_R(this,R)
+      this.R = R;
+      this.update_positions();
+    end
 
     function this = update_positions(this)
       % update mesh positions


### PR DESCRIPTION
The deform class has a set_new_C method to set new positions via code. To set new rotations as well, a set_R method was created.