### PR TITLE
Added second place to look for libigl.cmake

### DIFF
--- a/mex/cmake/FindLIBIGL.cmake
+++ b/mex/cmake/FindLIBIGL.cmake
@@ -33,4 +33,5 @@ find_package_handle_standard_args(LIBIGL
 mark_as_advanced(LIBIGL_INCLUDE_DIR)
 
 list(APPEND CMAKE_MODULE_PATH "${LIBIGL_INCLUDE_DIR}/../shared/cmake")
+list(APPEND CMAKE_MODULE_PATH "${LIBIGL_INCLUDE_DIR}/../cmake")
 include(libigl)


### PR DESCRIPTION
The libigl team recently restructured their module. Therefore libigl.cmake no longer resides in `${LIBIGL_INCLUDE_DIR}/../shared/cmake`. It is now located in `${LIBIGL_INCLUDE_DIR}/../cmake`. To maintain compatibility with old versions, I just added 
`list(APPEND CMAKE_MODULE_PATH "${LIBIGL_INCLUDE_DIR}/../cmake")`, so it should work with the recent version as well as the legacy version of libigl.