### PR TITLE
fix a typo in dual_laplacian

### DIFF
--- a/mex/dual_laplacian.cpp
+++ b/mex/dual_laplacian.cpp
@@ -2,7 +2,7 @@
 #include "mex.h"
 #include <igl/matlab/parse_rhs.h>
 #include <igl/matlab/prepare_lhs.h>
-#include <igl/matlab/mexStream.h>
+#include <igl/matlab/MexStream.h>
 #include <igl/matlab/mexErrMsgTxt.h>
 #include <Eigen/Core>
 #include <Eigen/Sparse>


### PR DESCRIPTION
As in the title. On case-sensitive OSes it will not compile without the fix.