### PR TITLE
fixed issue with CMake generator for multi-target compilers like VS2019

### DIFF
--- a/mex/CMakeLists.txt
+++ b/mex/CMakeLists.txt
@@ -8,9 +8,10 @@ set( CMAKE_CXX_STANDARD 14 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 
 # Move output to this dir (gptoolbox/mex)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
+# Solution for multitarget-generators like VS2019 From: https://stackoverflow.com/questions/47175912/using-cmake-how-to-stop-the-debug-and-release-subdirectories
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${PROJECT_SOURCE_DIR}>)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY $<1:${PROJECT_SOURCE_DIR}>)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY $<1:${PROJECT_SOURCE_DIR}>)
 
 # https://stackoverflow.com/q/46724267/148668
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
output now will be stored in /mex subfolder as expected.

Compilers like VS2019 will place generated mex files inside of <specified output directory>/<build target subfolder>/ (e.g. /mex/Release)

tested on win10 + vs2019