### PR TITLE
fix slice_triangles. Keep edge to intersected triangle pairing consis…

### DIFF
--- a/mesh/slice_triangles.m
+++ b/mesh/slice_triangles.m
@@ -34,6 +34,6 @@ function [U,E,J] = slice_triangles(V,F,plane,varargin)
   W = W(:,2:4);
   R = sign(sum(W.*N,2))>0;
   E(R,:) = fliplr(E(R,:));
-  E = unique(E,'rows');
-
+  [E, perm] = unique(E,'rows');
+  J = J(perm);
 end


### PR DESCRIPTION
slice_triangles returns 
E, a list of edges that are the set of intersections between a plane and the triangle mesh
J, a list of the intersected triangles
These should match in number of rows, but didn't because a unique was applied to E and not J. 
This fixes the issue.
