### PR TITLE
handled error in dual laplacian that makes sure input is indeed a tet…

### DIFF
--- a/mex/dual_laplacian.cpp
+++ b/mex/dual_laplacian.cpp
@@ -133,8 +133,7 @@ void mexFunction(
   parse_rhs_double(prhs+0,V);
   parse_rhs_index(prhs+1,T);
   Eigen::SparseMatrix<double> L,M;
-  mexErrMsgTxt(T.cols() > 4, "T should be indices into a tet-mesh");
-  mexErrMsgTxt(T.cols() < 4, "T should be indices into a tet-mesh");
+  mexErrMsgTxt(T.cols() == 4, "T should be indices into a tet-mesh");
   dualLaplace(V,T,L,M);
 
   switch(nlhs)

--- a/mex/dual_laplacian.cpp
+++ b/mex/dual_laplacian.cpp
@@ -133,6 +133,8 @@ void mexFunction(
   parse_rhs_double(prhs+0,V);
   parse_rhs_index(prhs+1,T);
   Eigen::SparseMatrix<double> L,M;
+  mexErrMsgTxt(T.cols() > 4, "T should be indices into a tet-mesh");
+  mexErrMsgTxt(T.cols() < 4, "T should be indices into a tet-mesh");
   dualLaplace(V,T,L,M);
 
   switch(nlhs)


### PR DESCRIPTION
…-mesh, stops matlab from crashing when calling dual_laplacian on triangle mesh