### PR TITLE
Removed issue with bsxfun doing full multiplication

### DIFF
--- a/mesh/loop.m
+++ b/mesh/loop.m
@@ -64,10 +64,18 @@ for i=1:iter
     %Sint = bsxfun(@times,A,beta) + diag(sparse(1-val.*beta));
     %S(interior,:) = Sint(interior,:);
     % construct interior coefficients directly
-    Seven(interior,:) = ...
-        bsxfun(@times,A(interior,:),beta(interior)) + ...
-        sparse(1:ni,original(interior),1-val(interior).*beta(interior),ni,no);
-
+    
+    % Old bsxfun approach (much slower!)
+    %Seven(interior,:) = ...
+    %    bsxfun(@times,A(interior,:),beta(interior)) + ...
+    %    sparse(1:ni,original(interior),1-val(interior).*beta(interior),ni,no);
+    
+    A_interior=A(interior,:); %Get only interior part of A
+    [rowIndices,~,~]=find(A_interior>0); %Get column insices for all non-zero entries
+    A_beta_interior=A_interior; %Initialize array for multiplication of A with beta
+    A_beta_interior(A_interior>0)=A_interior(A_interior>0).*beta(interior(rowIndices)); %Process multiplication only for non-zero entries
+    Seven(interior,:) = A_beta_interior + sparse(1:ni,original(interior),1-val(interior).*beta(interior),ni,no);
+    
     % construct boundary coefficients
     Sboundary = ...
         sparse([O(:,1);O(:,2)],[O(:,2);O(:,1)],1/8,n,n) + ...


### PR DESCRIPTION
This pull request "fixes" the poor performance of the `loop` function. For large meshes the old code becomes very slow. 

See here a simple test for icosahedron refinement: 
![slow](https://user-images.githubusercontent.com/8392709/125943837-b220d81a-96da-49d6-af74-14a34a0cb2a3.png)

The issue was with this line:
```matlab
Seven(interior,:) = ...
        bsxfun(@times,A(interior,:),beta(interior)) + ...
        sparse(1:ni,original(interior),1-val(interior).*beta(interior),ni,no);
```
In particular this part: 
```matlab
bsxfun(@times,A(interior,:),beta(interior))
```
The variable `A` is a sparse array. However `beta` is not. Hence if `interior` features `n` elements then `beta(interior)` is a full `nx1` array despite the fact that `A(interior,:)` is a sparse array. I am not sure if the inefficiency of the multiplication comes from the repeated use of the full column or if it temporarily creates a large full array that matches the size of `A(interior,:)`. Either way the following code removes the inefficiency and processing the multiplication only of the non-zero entries in `A(interior,:)`:
```matlab
A_interior=A(interior,:); %Get only interior part of A
    [rowIndices,~,~]=find(A_interior>0); %Get column insices for all non-zero entries
    A_beta_interior=A_interior; %Initialize array for multiplication of A with beta
    A_beta_interior(A_interior>0)=A_interior(A_interior>0).*beta(interior(rowIndices)); %Process multiplication only for non-zero entries
    Seven(interior,:) = A_beta_interior + sparse(1:ni,original(interior),1-val(interior).*beta(interior),ni,no);
```
Following this change the same performance graph becomes: 
![faster](https://user-images.githubusercontent.com/8392709/125944809-0e866b64-e297-4f4d-b48b-4b051351757d.png)

MATLAB version notes:
```
MATLAB Version: 9.10.0.1684407 (R2021a) Update 3
Operating System: Linux 5.4.0-77-generic #86-Ubuntu SMP Thu Jun 17 02:35:03 UTC 2021 x86_64
Java Version: Java 1.8.0_202-b08 with Oracle Corporation Java HotSpot(TM) 64-Bit Server VM mixed mode
```

Computer notes: 
```
CPU: Intel® Core™ i7-4910MQ CPU @ 2.90GHz × 8
RAM: 32Gb
```


