### PR TITLE
Fixing libigl import so that mex/ can be built

### DIFF
--- a/mex/cmake/libigl.cmake
+++ b/mex/cmake/libigl.cmake
@@ -6,6 +6,6 @@ include(FetchContent)
 FetchContent_Declare(
   libigl
   GIT_REPOSITORY https://github.com/libigl/libigl.git
-  GIT_TAG fe7e8281a4d92d422d8e516e155c3dd7cd26ab19
+  GIT_TAG 45a4f79b5ec72327c59758fc87f6fb72a9edffc8
 )
 FetchContent_MakeAvailable(libigl)


### PR DESCRIPTION
On my Ubuntu 18.04 machine, compiling the current version of gptoolbox returns

```
$ cmake ..
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test COMPILER_SUPPORTS_MARCH_NATIVE
-- Performing Test COMPILER_SUPPORTS_MARCH_NATIVE - Success
-- Found Matlab: /usr/local/MATLAB/R2019b/extern/include (found version "9.7") found components: MEX_COMPILER MX_LIBRARY ENG_LIBRARY
[ 11%] Creating directories for 'libigl-populate'
[ 22%] Performing download step (git clone) for 'libigl-populate'
Cloning into 'libigl-src'...
fatal: reference is not a tree: fe7e8281a4d92d422d8e516e155c3dd7cd26ab19
CMake Error at libigl-subbuild/libigl-populate-prefix/tmp/libigl-populate-gitclone.cmake:49 (message):
  Failed to checkout tag: 'fe7e8281a4d92d422d8e516e155c3dd7cd26ab19'


CMakeFiles/libigl-populate.dir/build.make:101: recipe for target 'libigl-populate-prefix/src/libigl-populate-stamp/libigl-populate-download' failed
make[2]: *** [libigl-populate-prefix/src/libigl-populate-stamp/libigl-populate-download] Error 1
CMakeFiles/Makefile2:82: recipe for target 'CMakeFiles/libigl-populate.dir/all' failed
make[1]: *** [CMakeFiles/libigl-populate.dir/all] Error 2
Makefile:90: recipe for target 'all' failed
make: *** [all] Error 2

CMake Error at /usr/share/cmake-3.23/Modules/FetchContent.cmake:1088 (message):
  Build step for libigl failed: 2
Call Stack (most recent call first):
  /usr/share/cmake-3.23/Modules/FetchContent.cmake:1217:EVAL:2 (__FetchContent_directPopulate)
  /usr/share/cmake-3.23/Modules/FetchContent.cmake:1217 (cmake_language)
  /usr/share/cmake-3.23/Modules/FetchContent.cmake:1260 (FetchContent_Populate)
  cmake/libigl.cmake:11 (FetchContent_MakeAvailable)
  CMakeLists.txt:77 (include)


-- Configuring incomplete, errors occurred!
```

Apparently, this is because the libigl version `mex/cmake/libigl.cmake` is pointing at is not part of any libigl branch. A hot fix that allows all Mex files to compile on my machine is to change it to the Jan 24 version of the libigl main branch, as in this change. 