### PR TITLE
fix to the index out of range bug in png2poly

### DIFF
--- a/mesh/point_inside_polygon.m
+++ b/mesh/point_inside_polygon.m
@@ -78,7 +78,10 @@ function interior_point = point_inside_polygon(V)
     second_hit = valid_second_hits(...
       distance_to_first_hit == min(distance_to_first_hit),:);
     % shouldn't have to do this:
-    second_hit = second_hit(1,:);
+    sz = size(second_hit);
+    if sz(1) >= 1
+        second_hit = second_hit(1,:);
+    end
 
     interior_point = (first_hit + second_hit)/2;
 end


### PR DESCRIPTION
When there are too many smoothing iterations for an image, png2poly crashes with an "index 1 out of range" error.

 This size check (admittedly, not the most elegant solution) fixes the bug!