### PR TITLE
Update libigl.cmake so it uses a commit with a non-deprecated boost archive

### DIFF
--- a/mex/cmake/libigl.cmake
+++ b/mex/cmake/libigl.cmake
@@ -6,6 +6,6 @@ include(FetchContent)
 FetchContent_Declare(
   libigl
   GIT_REPOSITORY https://github.com/libigl/libigl.git
-  GIT_TAG 667101084ac342f1f700299349452143069cbb4a
+  GIT_TAG 89267b4a80b1904de3f6f2812a2053e5e9332b7e
 )
 FetchContent_MakeAvailable(libigl)


### PR DESCRIPTION
Update libigl.cmake so it uses a commit with a non-deprecated boost archive

This should allow people without an independent libigl toolbox to just get all from vcpkg. Otherwise boost will try to fetch from jfrog rather than the archive.
The problem was seen both on windows and linux, so here is the one line fix.