### PR TITLE
Add support for cyclic (edge-based) indexing in `triangle_triangle_adjacency` and `edge_flaps`

### DIFF
--- a/mesh/edge_flaps.m
+++ b/mesh/edge_flaps.m
@@ -1,17 +1,45 @@
-function [EF,EI,uE,EMAP] = edge_flaps(F)
-  % [EF,EI,uE,EMAP] = edge_flaps(F)
+function [EF,EI,uE,EMAP] = edge_flaps(F, varargin)
+  % [EF,EI,uE,EMAP] = Build edge flaps and topological edge relationships 
+  % for a **manifold** triangle mesh.
+  %
+  % [EF, EI, uE, EMAP] = edge_flaps(F)
+  % [EF, EI, uE, EMAP] = edge_flaps(F, 'CornerIndexing')
+  % [EF, EI, uE, EMAP] = edge_flaps(F, 'CyclicIndexing')
+  %
+  % This function computes the "edge flaps" structure, describing for each unique
+  % edge which triangles it belongs to, and its local edge index within each triangle.
   %
   % Inputs:
   %   F  #F by 3 list of face indices
+  % Optional argument (mode):
+  %   'CornerIndexing' (default) - Uses corner-based indexing convention: local edge
+  %     indices are defined relative to the corner opposite each edge.
+  %   'CyclicIndexing' - Uses edge-based cyclic indexing convention: local edge
+  %     indices follow the order of edges (1→2, 2→3, 3→1) in each triangle.
   % Outputs:
-  %   EF  #E by 2 list of edge flaps, EF(e,0)=f means e=(i-->j) is the edge of
-  %     F(f,:) opposite the vth corner, where EI(e,0)=v. Similarly EF(e,1) "
-  %     e=(j->i)
-  %   EI  #E by 2 list of edge flap corners (see above).
-  %   uE  #uE by 2 list of edge indices into V.
-  %   EMAP #F by 3 list of indices into uE, mapping each directed edge to unique
-  %     unique edge in uE
-  %
+  %   EF   #E by 2 matrix of "edge flaps". Each row corresponds to a unique edge.
+  %        EF(e,1) is the index of the first adjacent face (triangle) that contains
+  %        edge e in the direction (uE(e,1) → uE(e,2)). EF(e,2) is the index of the
+  %        second adjacent face containing the same edge but in the opposite direction
+  %        (uE(e,2) → uE(e,1)).
+  %        If an edge is a boundary edge, then one of the entries in EF(e,:) will be 0.
+  %   EI   #E by 2 matrix of local edge indices within the adjacent triangles
+  %        corresponding to EF. Indices are 1-based and depend on the indexing mode.
+  %   uE   #uE by 2 list of unique edges as vertex index pairs.
+  %   EMAP #F by 3 matrix mapping each directed edge in F to its unique edge index in uE. 
+  
+  % Default mode
+  mode = 'CornerIndexing';
+
+  % Parse optional argument
+  if ~isempty(varargin)
+    if ischar(varargin{1}) || isstring(varargin{1})
+      mode = varargin{1};
+    else
+      error('Optional argument must be a string: ''CornerIndexing'' or ''CyclicIndexing''.');
+    end
+  end
+
   E = [F(:,2:3);F(:,[3 1]);F(:,1:2)];
   sE = sort(E,2);
   [uE,~,EMAP] = unique(sE,'rows');
@@ -29,4 +57,19 @@ function [EF,EI,uE,EMAP] = edge_flaps(F)
   K2 = repmat(2,numel(I2),1);
   EF = full(sparse([I1;I2],[K1;K2],[J1;J2],size(uE,1),2));
   EI = full(sparse([I1;I2],[K1;K2],[C1;C2],size(uE,1),2));
+
+  % Apply cyclic reordering if requested
+  if strcmpi(mode, 'CyclicIndexing')
+    % Remap local edge indices
+    i1 = EI == 1;
+    i2 = EI == 2;
+    i3 = EI == 3;
+    EI(i3) = 1;
+    EI(i1) = 2;
+    EI(i2) = 3;
+    % Reorder EMAP columns
+    EMAP = [EMAP(:,3), EMAP(:,1), EMAP(:,2)];
+  elseif ~strcmpi(mode, 'CornerIndexing')
+    error('Unknown indexing mode. Use ''CornerIndexing'' or ''CyclicIndexing''.');
+  end
 end

--- a/mesh/triangle_triangle_adjacency.m
+++ b/mesh/triangle_triangle_adjacency.m
@@ -95,7 +95,8 @@ function [Fp, Fi] = triangle_triangle_adjacency(F, varargin)
   if strcmpi(mode, 'CyclicIndexing')
     Fp = [Fp(:,3), Fp(:,1), Fp(:,2)];
     Fi = [Fi(:,3), Fi(:,1), Fi(:,2)];
-    Fi = mod(Fi,3)+1;
+    I = Fi ~= -1;
+    Fi(I) = mod(Fi(I),3)+1;
   elseif ~strcmpi(mode, 'CornerIndexing')
     error('Unknown indexing mode. Use ''CornerIndexing'' or ''CyclicIndexing''.');
   end

--- a/mesh/triangle_triangle_adjacency.m
+++ b/mesh/triangle_triangle_adjacency.m
@@ -95,6 +95,7 @@ function [Fp, Fi] = triangle_triangle_adjacency(F, varargin)
   if strcmpi(mode, 'CyclicIndexing')
     Fp = [Fp(:,3), Fp(:,1), Fp(:,2)];
     Fi = [Fi(:,3), Fi(:,1), Fi(:,2)];
+    Fi = mod(Fi,3)+1;
   elseif ~strcmpi(mode, 'CornerIndexing')
     error('Unknown indexing mode. Use ''CornerIndexing'' or ''CyclicIndexing''.');
   end


### PR DESCRIPTION
### Motivation

The original functions `triangle_triangle_adjacency` and `edge_flaps` currently use **corner-based indexing**, where each local edge index is defined by the edge opposite a specific vertex in a triangle.

While this convention is mathematically natural, some applications benefit from a more direct **edge-based cyclic indexing**, where edges are indexed in the order of the vertices as they appear in each face (i.e., edges 1→2, 2→3, 3→1).

### Changes

Added support for an **optional argument** (`'CornerIndexing'` or `'CyclicIndexing'`) to both functions:

* `triangle_triangle_adjacency(F, mode)`
* `edge_flaps(F, mode)`

By default, the original **corner-based indexing** is preserved to ensure backward compatibility.

When `'CyclicIndexing'` is specified:

* In `triangle_triangle_adjacency`, the neighboring faces and corresponding local edge positions are reordered so that the j-th entry refers to the j-th edge in cyclic order.
* In `edge_flaps`, local edge indices (`EI`) and `EMAP` are remapped accordingly, following cyclic edge order.

### Example usage

```matlab
[Fp, Fi] = triangle_triangle_adjacency(F, 'CyclicIndexing');
[EF, EI, uE, EMAP] = edge_flaps(F, 'CyclicIndexing');
```

### Benefits

* Provides a more intuitive indexing option for workflows relying on explicit edge traversal.
* Makes the functions more flexible without affecting existing users.

### Notes

* Full backward compatibility is maintained.
* Clear error messages are added for invalid indexing mode arguments.
* Function documentation was updated to describe both indexing conventions in detail.

